### PR TITLE
use VT100 RIS to clear screen

### DIFF
--- a/AnsiLib.ml
+++ b/AnsiLib.ml
@@ -4,7 +4,7 @@
  * themselves are pretty opaque, and giving the routines names makes code
  * considerably more readable. *)
 
-let clear_screen () = "\027c"
+let clear_screen () = "\027[H\027[J"
 
 type attribute = Reset | Bright | Dim | Underscore | Blink | Reverse | Hidden
 type color = Black | Red | Green | Yellow | Blue | Magenta | Cyan | White

--- a/AnsiLib.ml
+++ b/AnsiLib.ml
@@ -4,7 +4,7 @@
  * themselves are pretty opaque, and giving the routines names makes code
  * considerably more readable. *)
 
-let clear_screen () = "\027[2J"
+let clear_screen () = "\027c"
 
 type attribute = Reset | Bright | Dim | Underscore | Blink | Reverse | Hidden
 type color = Black | Red | Green | Yellow | Blue | Magenta | Cyan | White


### PR DESCRIPTION
Running `agenda` for a long time in Terminal.app very slowly fills the scrollback buffer, which in turn very slowly causes performance degradation. Terminal.app implements `CSI 2 J` by pushing the current contents of the screen into scrollback, but it implements `ESC c` by clearing the current contents of the screen without pushing anything into scrollback. This PR changes which escape code `agenda` uses.

`ESC c` is the VT100 command `RIS`, which I learned about [on SO](https://stackoverflow.com/a/37778152/19242027). That post comes with some warnings about how it causes unpleasant side-effects on certain hardware. I don't really understand the risks here, so I'll let this sit open as a PR, rather than merging to main like I normally do.